### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
       url='https://github.com/nrgpy/nrgpy',
       author='NRG Systems, Inc.',
       author_email='support@nrgsystems.com',
-      license='MIT',
       keywords='nrg systems rld symphonie symphoniepro wind data',
       packages=[
             'nrgpy'
@@ -24,5 +23,8 @@ setup(
             'requests',
       ],
       python_requires='>=3.0',
-      zip_safe=False
+      zip_safe=False,
+      classifiers=[
+          'License :: OSI Approved :: MIT License'
+      ]
 )


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.