### PR TITLE
Call count_files with convert_time instead of start_time

### DIFF
--- a/nrgpy/convert_rwd.py
+++ b/nrgpy/convert_rwd.py
@@ -134,7 +134,7 @@ class local(object):
                 print('file conversion failed on {}'.format(self._filename))
             self.counter += 1
         txt_count = count_files(self.out_dir, self.file_filter.split(".")[0], 'txt', start_time=self.convert_time)
-        log_count, log_files = count_files(self.out_dir, self.file_filter, 'log', show_files=True, start_time=self.start_time)
+        log_count, log_files = count_files(self.out_dir, self.file_filter, 'log', show_files=True, start_time=self.convert_time)
         print('\nRWDs in    : {}'.format(self.raw_count))
         print('TXTs out   : {}'.format(txt_count))
         print('LOGs out   : {}'.format(log_count))


### PR DESCRIPTION
After rwd files are converted in nrgpy.convert_rwd.local.convert, there are steps to count the .txt files and the .log files. The count_files call for the .txt files uses self.convert_time (a float), but the one for .log files uses self.start_time (a datetime) - which fails. I changed it without giving it a lot of scrutiny, so you shouldn't blindly accept this...

Another warning... I've only done one pull request  - and that was years ago.

```
(env) PS C:\Users\todd.koym\projects2\metl> metl-convert-rwd.exe .\etc\development.ini 
SDR test OK!
Converting    1/30   111420200325676.RWD  ...  [DONE]
Unable to copy 111420200325676.txt to C:\Users\todd.koym\Documents\Renewable NRG Systems\Exports\
Converting    2/30   111420200325678.RWD  ...  [DONE]
Converting    3/30   111420200325680.RWD  ...  [DONE]
Unable to copy 111420200325680.txt to C:\Users\todd.koym\Documents\Renewable NRG Systems\Exports\
Converting    4/30   111420200325682.RWD  ...  [DONE]
Unable to copy 111420200325682.txt to C:\Users\todd.koym\Documents\Renewable NRG Systems\Exports\
Converting    6/30   130320200411684.RWD  ...  [DONE]
Converting    7/30   130320200412685.RWD  ...  [DONE]
Converting    8/30   210120200411184.RWD  ...  [DONE]
Converting    9/30   210120200412185.RWD  ...  [DONE]
Converting   10/30   240620200412818.RWD  ...  [DONE]
Converting   11/30   400320200411085.RWD  ...  [DONE]
Converting   12/30   400320200412086.RWD  ...  [DONE]
Converting   13/30   400520200411082.RWD  ...  [DONE]
Converting   14/30   400520200412083.RWD  ...  [DONE]
Converting   15/30   470220200412070.RWD  ...  [DONE]
Converting   16/30   490420200412827.RWD  ...  [DONE]
Converting   17/30   573620200412356.RWD  ...  [DONE]
Converting   18/30   573620200413357.RWD  ...  [DONE]
Converting   19/30   600120200411249.RWD  ...  [DONE]
Converting   20/30   600120200412250.RWD  ...  [DONE]
Converting   21/30   637120200412033.RWD  ...  [DONE]
Converting   22/30   637120200413034.RWD  ...  [DONE]
Converting   23/30   850320200412030.RWD  ...  [DONE]
Converting   24/30   850320200413031.RWD  ...  [DONE]
Converting   25/30   905320200412304.RWD  ...  [DONE]
Converting   26/30   905320200413305.RWD  ...  [DONE]
Converting   27/30   981220200412829.RWD  ...  [DONE]
Converting   28/30   990120200412795.RWD  ...  [DONE]
Converting   29/30   990120200413796.RWD  ...  [DONE]
Unable to copy 990120200413796.txt to C:\Users\todd.koym\Documents\Renewable NRG Systems\Exports\
Converting   30/30   991020200412081.RWD  ...  [DONE]
Traceback (most recent call last):
  File "C:\Users\todd.koym\projects2\metl\env\Scripts\metl-convert-rwd-script.py", line 11, in <module>
    load_entry_point('metl', 'console_scripts', 'metl-convert-rwd')()
  File "c:\users\todd.koym\projects2\metl\src\metl\cli.py", line 112, in convert_rwd
    converter.convert()
  File "c:\users\todd.koym\documents\github\nrgpy\nrgpy\convert_rwd.py", line 137, in convert
    log_count, log_files = count_files(self.out_dir, self.file_filter, 'log', show_files=True, start_time=self.start_time)
  File "c:\users\todd.koym\documents\github\nrgpy\nrgpy\utilities.py", line 65, in count_files
    if os.path.getmtime(os.path.join(dirpath,x)) > start_time:
TypeError: '>' not supported between instances of 'float' and 'datetime.datetime'
(env) PS C:\Users\todd.koym\projects2\metl>
```