### PR TITLE
Update sympro_txt.py

### DIFF
--- a/nrgpy/sympro_txt.py
+++ b/nrgpy/sympro_txt.py
@@ -318,7 +318,10 @@ class sympro_txt_read(object):
                     except IndexError:
                         print('Only standard SymPRO headertypes accepted')
                         break
-        
+                    except:
+                        if progress_bar != True: print("[FAILED]")
+                        print("could not concat {0}".format(os.path.basename(file_path)))
+                        pass
                 else:
                     file_path = f
         


### PR DESCRIPTION
The sympro file concatenation currently fails if the first file is empty i.e. EmptyDataError (or if the exception is not caught by the IndexError). The suggested fix here is to simply move the generic Exception handler to cover the first file.