### PR TITLE
updated to accommodate nrg cloud export concat txt names

### DIFF
--- a/nrgpy/utils/utilities.py
+++ b/nrgpy/utils/utilities.py
@@ -97,10 +97,14 @@ def string_date_check(start_date: str, end_date: str, string: str) -> bool:
     # SymphoniePRO
     date_format_with_dash = "([0-9]{4}\-[0-9]{2}\-[0-9]{2})"
     strp_format_with_dash = "%Y-%m-%d"
+    # NRG Cloud TXT Export
+    date_format_with_dot = "([0-9]{4}\.[0-9]{2}\.[0-9]{2})"
+    strp_format_with_dot = "%Y.%m.%d"
+
 
     try:
-        start = datetime.strptime(start_date, "%Y-%m-%d")
-        end = datetime.strptime(end_date, "%Y-%m-%d")
+        start = datetime.strptime(start_date, strp_format_with_dash)
+        end = datetime.strptime(end_date, strp_format_with_dash)
     except TypeError:
         print(traceback.format_exc())
         start = start_date
@@ -118,6 +122,9 @@ def string_date_check(start_date: str, end_date: str, string: str) -> bool:
     elif re.search(date_format_with_dash, string):
         date_text = re.search(date_format_with_dash, string)
         file_date = datetime.strptime(date_text[0], strp_format_with_dash)
+    elif re.search(date_format_with_dot, string):
+        date_text = re.search(date_format_with_dot, string)
+        file_date = datetime.strptime(date_text[0], strp_format_with_dot)
     elif re.search(date_format_zx, string):
         date_text = re.search(date_format_zx, string)
         file_date = datetime.strptime(date_text[0], strp_format_zx)

--- a/tests/utilities/test_utilities.py
+++ b/tests/utilities/test_utilities.py
@@ -85,4 +85,15 @@ class TestDateCheck:
         assert (
             result
         ), f"expected True result from start: {start_date}, end: {end_date}, string: {string}"  # noqa: E501
-        pass
+
+    def test_nrg_cloud_format_passes(self):
+        # arrange
+        start_date = "2024-01-01"
+        end_date = "2024-01-10"
+        string = "006716_SunnyDog_meas_2024.01.02-2024.01.08.txt"
+        # act
+        result = string_date_check(start_date, end_date, string)
+        # assert
+        assert (
+            result
+        ), f"expected True result from start: {start_date}, end: {end_date}, string: {string}"  # noqa: E501


### PR DESCRIPTION
YR found this bug today. @AEArntsen  would you mind doing a quick review? this allows for nrgpy to concat the "%Y.%m.%d" date format of NRG Cloud concatenated data export text files.